### PR TITLE
sync

### DIFF
--- a/anyvm.py
+++ b/anyvm.py
@@ -74,7 +74,7 @@ OPENBSD_E1000_RELEASES = {"7.3", "7.4", "7.5", "7.6"}
 
 
 DEFAULT_BUILDER_VERSIONS = {
-    "freebsd": "2.0.5",
+    "freebsd": "2.0.7",
     "openbsd": "2.0.0",
     "netbsd": "2.0.3",
     "dragonflybsd": "2.0.3",


### PR DESCRIPTION
sync
This pull request updates the `anyvm.py` file with improvements to the terminal connection logic and updates to builder version defaults. The most important changes are the introduction of a connection state flag to prevent premature terminal input handling, improvements to data decoding and writing logic, and updates to builder version numbers.



Builder version updates:
* Updated the default builder versions for `freebsd` (from `2.0.5` to `2.0.7`) and `omnios` (from `2.0.3` to `2.0.4`).